### PR TITLE
Обслуживание_индексов_нескольких_БД.sql

### DIFF
--- a/Обслуживание_индексов_нескольких_БД.sql
+++ b/Обслуживание_индексов_нескольких_БД.sql
@@ -18,9 +18,9 @@
 DECLARE @namelike varchar(100) = '%'
 
 -- Имя почтового профиля, для отправки электонной почты									
-DECLARE @profilename as nvarchar(100) = 'mail.ru'
+DECLARE @profilename as nvarchar(100) = 'profile'
 -- Получатели сообщений электронной почты, разделенные знаком ";"				
-DECLARE @recipients as nvarchar(500) = 'ivanov@kpd-cargo.com'
+DECLARE @recipients as nvarchar(500) = 'admin@mydomen.com'
 
 -------------------------------------------
 -- СЛУЖЕБНЫЕ ПЕРЕМЕННЫЕ 


### PR DESCRIPTION
-- Чуть доработал Serge V. Ivanov в свзяи с тем, что 1С версий 8.3.22.хххх отключает блокировку страниц для всех индексов. 
--    для возможности выполнения реорганизации или перестроения ее необходимо включать. Потом выключать.